### PR TITLE
Switch to using argparse for input and a grid for output

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,11 @@ This will install all necessary dependencies.
 
 To use the tool, run:
 ```sh
-python src/license_explorer.py
+python src/vanity.py bread --distance 1
 ```
 
 Here's some example output:
 ```
-Enter word to start:BREAD
-Enter max distance to output: 1
 DISTANCE 0
          Option(word='BREAD', distance=0)
 DISTANCE 1

--- a/README.md
+++ b/README.md
@@ -26,21 +26,31 @@ This will install all necessary dependencies.
 
 To use the tool, run:
 ```sh
-python src/vanity.py bread --distance 1
+python src/vanity.py bread
 ```
 
 Here's some example output:
 ```
 DISTANCE 0
-         Option(word='BREAD', distance=0)
+         BREAD     
 DISTANCE 1
-         Option(word='8READ', distance=1)
-         Option(word='BAKERY', distance=1)
-         Option(word='BR3AD', distance=1)
-         Option(word='BRAD', distance=1)
-         Option(word='BRE4D', distance=1)
-         Option(word='BRED', distance=1)
-         Option(word='LOAF', distance=1)
+         8READ     BAKERY    BR3AD     BRAD      BRE4D     BRED      LOAF
+DISTANCE 2
+         1OAF      8AKERY    8R3AD     8RAD      8RE4D     8RED      B4KERY    BAK3RY    BAKE      BAKED
+         BAKING    BAKRY     BARD      BKERY     BR34D     BR3D      BR4D      BRD       BUN       L0AF
+         LAF       LO4F      LOF       RAD       REARED    ROAST
+DISTANCE 3
+         10AF      1AF       1O4F      1OF       84KERY    8AK3RY    8AKE      8AKED     8AKING    8AKRY
+         8ARD      8KERY     8R34D     8R3D      8R4D      8RD       8UN       B4K3RY    B4KE      B4KED
+         B4KING    B4KRY     B4RD      BAK1NG    BAK3      BAK3D     BAKD      BAKIN9    BAKNG     BK3RY
+         BKE       BKED      BKING     BKRY      BN        COOK      COOKING   FDR       KEPT      L04F
+         L0F       L4F       LF        POET      R0AST     R3ARED    R4D       RARED     RAST      RD
+         RE4RED    REARD     RERED     RO4ST     ROA5T     ROAS7     ROASTING  ROOSEVELT ROST      STEAK
+```
+
+To see options, run:
+```sh
+python src/vanity.py -h
 ```
 
 ## Contribute

--- a/src/license_explorer.py
+++ b/src/license_explorer.py
@@ -25,10 +25,15 @@ def explore(input_word, max_distance, output_width, max_length):
     word_set = set()
     word_set.add(Option(word=word, distance=0))
 
-    while distance_traveled <= max_distance:
+    all_options_processed = False
+    while distance_traveled <= max_distance and not all_options_processed:
         print_options_at_distance(distance_traveled, word_set, output_width, max_length)
         new_words = []
+        all_options_processed = True
         for existing_option in word_set:
+            if existing_option.distance < distance_traveled:
+                continue
+            all_options_processed = False
             for f in transformation_functions.keys():
                 distance_out = transformation_functions[f] + distance_traveled
                 if distance_out > max_distance:

--- a/src/license_explorer.py
+++ b/src/license_explorer.py
@@ -1,9 +1,6 @@
 from utils import Option
 from utils import print_options_at_distance
 
-print("Initializing...")
-# Because this parses the dictionary at import time, it takes some time, 
-# but less than you'd expect.
 from transformations import transform_letters_to_numbers
 from transformations import transform_substrings_to_numbers
 from transformations import remove_middle_vowels
@@ -22,26 +19,25 @@ transformation_functions = {
     remove_start_or_end: 10,
 }
 
-word = input("Enter word to start:").strip().upper()
-max_distance = int(input("Enter max distance to output: "))
+def explore(input_word, max_distance):
+    word = input_word.strip().upper()
+    distance_traveled = 0
+    word_set = set()
+    word_set.add(Option(word=word, distance=0))
 
-distance_traveled = 0
-word_set = set()
-word_set.add(Option(word=word, distance=0))
+    while distance_traveled <= max_distance:
+        print_options_at_distance(distance_traveled, word_set)
+        new_words = []
+        for existing_option in word_set:
+            for f in transformation_functions.keys():
+                distance_out = transformation_functions[f] + distance_traveled
+                if distance_out > max_distance:
+                    continue
+                derived = f(existing_option)
+                for d in derived:
+                    new_words.append((d, distance_out))
 
-while distance_traveled <= max_distance:
-    print_options_at_distance(distance_traveled, word_set)
-    new_words = []
-    for existing_option in word_set:
-        for f in transformation_functions.keys():
-            distance_out = transformation_functions[f] + distance_traveled
-            if distance_out > max_distance:
-                continue
-            derived = f(existing_option)
-            for d in derived:
-                new_words.append((d, distance_out))
+        for w in new_words:
+            word_set.add(Option(word=w[0], distance=w[1]))
 
-    for w in new_words:
-        word_set.add(Option(word=w[0], distance=w[1]))
-
-    distance_traveled += 1
+        distance_traveled += 1

--- a/src/license_explorer.py
+++ b/src/license_explorer.py
@@ -19,14 +19,14 @@ transformation_functions = {
     remove_start_or_end: 10,
 }
 
-def explore(input_word, max_distance):
+def explore(input_word, max_distance, output_width, max_length):
     word = input_word.strip().upper()
     distance_traveled = 0
     word_set = set()
     word_set.add(Option(word=word, distance=0))
 
     while distance_traveled <= max_distance:
-        print_options_at_distance(distance_traveled, word_set)
+        print_options_at_distance(distance_traveled, word_set, output_width, max_length)
         new_words = []
         for existing_option in word_set:
             for f in transformation_functions.keys():

--- a/src/transformations.py
+++ b/src/transformations.py
@@ -1,7 +1,7 @@
 from dictionary_builder import get_dictionary
 
 vowels = ["A", "E", "I", "O", "U"]
-consinents = [
+consonants = [
     "B", "C", "D", "F", "G",
     "H", "J", "K", "L", "M",
     "N", "P", "Q", "R", "S",

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
 
-def print_options_at_distance(d, words):
+def print_options_at_distance(d, words, width, max_length):
     print(f"DISTANCE {d}")
-    
-    for w in sorted(words, key=lambda e: e.word):
-        if w.distance == d:
-            print("\t", w)
+    filtered = (w.word for w in words if w.distance == d and len(w.word) <= max_length)
+    print_grouped(sorted(filtered), width)
+
+def print_grouped(words, width):
+    grouped = [words[i:i+width] for i in range(0, len(words), width)]
+    for g in grouped:
+        print("\t", "".join("{:<10}".format(w) for w in g))
 
 @dataclass
 class Option:

--- a/src/vanity.py
+++ b/src/vanity.py
@@ -1,0 +1,12 @@
+import argparse
+
+import license_explorer
+
+parser = argparse.ArgumentParser(description="Searches for vanity license plates.")
+parser.add_argument("input", 
+                    help="The seed for the search, something like BREAD")
+parser.add_argument("-d", "--distance", type=int, default=3, 
+                    help="The maximum distance to search (3 by default)")
+
+args = parser.parse_args()
+license_explorer.explore(args.input, args.distance)

--- a/src/vanity.py
+++ b/src/vanity.py
@@ -7,6 +7,10 @@ parser.add_argument("input",
                     help="The seed for the search, something like BREAD")
 parser.add_argument("-d", "--distance", type=int, default=3, 
                     help="The maximum distance to search (3 by default)")
+parser.add_argument("-w", "--output-width", type=int, default=10, 
+                    help="The maximum number of output per line in the output (10 by default)")
+parser.add_argument("-m", "--max-length", type=int, default=7, 
+                    help="The maximum length of the outputs (7 by default)")
 
 args = parser.parse_args()
-license_explorer.explore(args.input, args.distance)
+license_explorer.explore(args.input, args.distance, args.output_width, args.max_length)


### PR DESCRIPTION
This makes four changes:
1. Instead of prompting for input, parse command line parameters. This also moves the main file to vanity.py.
2. The output is now a grid instead of a list to make it easier to read.
3. Output length is now limited to 7 characters (configurable).
4. Detect that all words have been processed and stop.

Also, fix a typo.

New parameters:
```
  input
  -d, --distance (default 3)
  -w, --output-width (default 10)
  -m, --max-length (default 7)
```