### PR TITLE
Add --dmv-test option to query CA DMV

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ To see options, run:
 python src/vanity.py -h
 ```
 
+You can also use the experimental `--dmv-test` flag to check the California DMV
+to see if the vanity plate is available. This capability will be incorporated
+into the main search tool, and eventually include other states.
+
+```sh
+$ python src/vanity.py bread --dmv-test 
+Is "bread" available as a CA DMV license plate?...
+False
+
+$ python src/vanity.py 8AK3RY --dmv-test
+Is "8AK3RY" available as a CA DMV license plate?...
+True
+```
+
 ## Contribute
 
 If you add any dependencies, make sure to export the changes:

--- a/src/dmv.py
+++ b/src/dmv.py
@@ -1,0 +1,99 @@
+import requests
+
+class CA_DMV():
+    API_ROOT = "https://www.dmv.ca.gov/wasapp/ipp2"
+    PATH_INIT = "initPers.do"
+    PATH_START = "startPers.do"
+    PATH_PROCESS = "processPers.do"
+    PATH_PLATE = "processConfigPlate.do"
+
+    START_DATA = {
+        "acknowledged": "true", 
+        "_acknowledged": "on",
+    }
+    PROCESS_DATA = {
+        "imageSelected": "none",
+        "vehicleType": "AUTO",
+        "licPlateReplaced": "GITHUB",
+        "last3Vin": "166",
+        "isRegExpire60": "no",
+        "isVehLeased": "no",
+        "plateType": "R",
+    }
+    PLATE_DATA = {
+            "kidsPlate": "",
+            "plateType": "R",
+            "plateLength": "7",
+            "plateNameLow": "environmental",
+            "plateChar0": "",
+            "plateChar1": "",
+            "plateChar2": "",
+            "plateChar3": "",
+            "plateChar4": "",
+            "plateChar5": "",
+            "plateChar6": "",
+        }
+    PLATE_CHAR_PREFIX = "plateChar"
+    MIN_LENGTH = 2
+    MAX_LENGTH = 7
+    SUCCESS_PHRASE = "id=\"PersonalizedFormBean\""
+    FAILURE_PHRASE = "id=\"plate-configurator\""
+
+    def __init__(self):
+        self.session = None
+
+    def initialize(self):
+        self.check_initialized(force = True)
+
+    def checkPlate(self, word):
+        self.check_initialized(force = False)
+        data = CA_DMV.buildPlateRequestData(word)
+        if not data:
+            print("Invalid input, can't check the DMV.")
+            return False
+        result = self.session.post(
+            url = CA_DMV.dmvUrl(CA_DMV.PATH_PLATE), 
+            data = data,
+        )
+        available = CA_DMV.checkPlateResult(result)
+        if available is None:
+            print("Got an unknown result for a plate, neither success nor failure!")
+            return False
+        return available
+
+    def check_initialized(self, force = False):
+        if not self.session or force:
+            self.session = CA_DMV.initDmvSession()
+
+    def dmvUrl(page):
+        return "{}/{}".format(CA_DMV.API_ROOT, page)
+
+    def initDmvSession():
+        session = requests.Session()
+        session.get(url = CA_DMV.dmvUrl(CA_DMV.PATH_INIT))
+        session.post(
+            url = CA_DMV.dmvUrl(CA_DMV.PATH_START), 
+            data = CA_DMV.PROCESS_DATA,
+        )
+        session.post(
+            url = CA_DMV.dmvUrl(CA_DMV.PATH_PROCESS), 
+            data = CA_DMV.START_DATA,
+        )
+        return session
+
+    def buildPlateRequestData(word):
+        if len(word) < CA_DMV.MIN_LENGTH or len(word) > CA_DMV.MAX_LENGTH:
+            return None
+        data = CA_DMV.PLATE_DATA.copy()
+        for idx, char in enumerate(word):
+            param = "{}{}".format(CA_DMV.PLATE_CHAR_PREFIX, idx)
+            data[param] = char
+        return data
+
+    def checkPlateResult(response):
+        if CA_DMV.SUCCESS_PHRASE in response.text:
+            return True
+        elif CA_DMV.FAILURE_PHRASE in response.text:
+            return False
+        else:
+            return None

--- a/src/vanity.py
+++ b/src/vanity.py
@@ -1,6 +1,7 @@
 import argparse
 
 import license_explorer
+from dmv import CA_DMV
 
 parser = argparse.ArgumentParser(description="Searches for vanity license plates.")
 parser.add_argument("input", 
@@ -11,6 +12,13 @@ parser.add_argument("-w", "--output-width", type=int, default=10,
                     help="The maximum number of output per line in the output (10 by default)")
 parser.add_argument("-m", "--max-length", type=int, default=7, 
                     help="The maximum length of the outputs (7 by default)")
-
+parser.add_argument("--dmv-test", dest="dmv_test", action="store_true",
+                    help="if used, check the input against the CA DMV registry")
 args = parser.parse_args()
-license_explorer.explore(args.input, args.distance, args.output_width, args.max_length)
+
+if (args.dmv_test):
+    print("Is \"{}\" available as a CA DMV license plate?...".format(args.input))
+    dmv = CA_DMV()
+    print(dmv.checkPlate(args.input))
+else:
+    license_explorer.explore(args.input, args.distance, args.output_width, args.max_length)


### PR DESCRIPTION
I figured out how to query the CA DMV by going to their [SPECIAL INTEREST AND PERSONALIZED LICENSE PLATES ORDERS
](https://www.dmv.ca.gov/portal/vehicle-registration/license-plates-decals-and-placards/california-license-plates/order-special-interest-and-personalized-license-plates/) page, clicking "Order personalized plates", and squinting at Chrome's network tab.

Note that we need to use the `session` object to make each request because the DMV site sends back a lot of cookies to track the session.

I used [vehiclehistory.com](https://www.vehiclehistory.com/license-plate-search) to look up the VIN of the car with the license plate `"GITHUB"` because we need a valid license plate + VIN combo to make the query. So if that car changes its license plate, this'll need to be updated. To make that more robust we could include a list of pairs to try.

Special thanks to @zeke and his [california-license-plates](https://github.com/zeke/california-license-plates) repo for providing a good reference for form parameters.

Finally, here's a sample showing how the new option works, also included in the `README.md`:
```sh
$ python src/vanity.py bread --dmv-test 
Is "bread" available as a CA DMV license plate?...
False

$ python src/vanity.py 8AK3RY --dmv-test
Is "8AK3RY" available as a CA DMV license plate?...
True
```

Next steps will be incorporating this into the license plate search.