### PR TITLE
Add caching for DMV requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Install conda (through [anaconda](https://docs.anaconda.com/anaconda/install/) or [miniconda](https://docs.conda.io/en/latest/miniconda.html)), then run:
 
 ```sh
-conda env create -f conda.yaml
+conda env update -f conda.yaml --prune
 conda activate vanity
 ```
 

--- a/conda.yaml
+++ b/conda.yaml
@@ -3,3 +3,4 @@ channels:
   - defaults
 dependencies:
   - python=3.8
+  - appdirs=1.4.4

--- a/conda.yaml
+++ b/conda.yaml
@@ -4,3 +4,4 @@ channels:
 dependencies:
   - python=3.8
   - appdirs=1.4.4
+  - requests=2.27.1

--- a/src/dmv.py
+++ b/src/dmv.py
@@ -2,10 +2,8 @@ import json
 import logging
 import os
 import os.path
-import platform
 import re
 import requests
-import sys
 
 from enum import Enum
 from pathlib import Path

--- a/src/dmv.py
+++ b/src/dmv.py
@@ -41,15 +41,17 @@ class CA_DMV():
 
     def __init__(self):
         self.session = None
-        self.cache = {}
+        self.cache = None
 
     def initialize(self):
-        self.check_initialized(force = True)
+        self.check_cache_initialized(force = True)
+        self.check_session_initialized(force = True)
 
     def check_plate(self, word):
+        self.check_cache_initialized(force = False)
         if word in self.cache:
             return self.cache[word]
-        self.check_initialized(force = False)
+        self.check_session_initialized(force = False)
         data = CA_DMV.build_plate_request_data(word)
         if not data:
             print("Invalid input, can't check the DMV.")
@@ -65,9 +67,13 @@ class CA_DMV():
         self.cache[word] = available
         return available
 
-    def check_initialized(self, force = False):
-        if not self.session or force:
+    def check_session_initialized(self, force = False):
+        if self.session is None or force:
             self.session = CA_DMV.init_dmv_session()
+
+    def check_cache_initialized(self, force = False):
+        if self.cache is None or force:
+            self.cache = {}
 
     def dmv_url(page):
         return "{}/{}".format(CA_DMV.API_ROOT, page)

--- a/src/dmv.py
+++ b/src/dmv.py
@@ -2,7 +2,9 @@ import json
 import logging
 import os
 import os.path
+import platform
 import requests
+import sys
 
 from enum import Enum
 from pathlib import Path
@@ -64,7 +66,8 @@ class CA_DMV():
     SUCCESS_PHRASE = "id=\"PersonalizedFormBean\""
     FAILURE_PHRASE = "id=\"plate-configurator\""
 
-    CACHE_PATH = "~/.cache/vanity/ca_dmv.json"
+    APPNAME = "vanity"
+    CACHE_FILE = "ca_dmv.json"
 
     def __init__(self, cache_option = CacheOption.DEFAULT):
         self.session = None
@@ -153,7 +156,8 @@ class CA_DMV():
             logger.debug("Could not clear disk cache - does not exist")
 
     def get_cache_path():
-        return os.path.expanduser(CA_DMV.CACHE_PATH)
+        cache_dir = CA_DMV.user_cache_dir(CA_DMV.APPNAME)
+        return os.path.join(cache_dir, CA_DMV.CACHE_FILE)
 
     def dmv_url(page):
         return "{}/{}".format(CA_DMV.API_ROOT, page)
@@ -187,3 +191,50 @@ class CA_DMV():
             return False
         else:
             return None
+
+    # adapted from https://github.com/ActiveState/appdirs
+    def user_cache_dir(appname):
+        r"""Return full path to the user-specific cache dir for this application.
+
+        "appname" is the name of application.
+
+        Typical user cache directories are:
+            Mac OS X:   ~/Library/Caches/<AppName>
+            Unix:       ~/.cache/<AppName> (XDG default)
+            Win XP:     C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Cache
+            Vista:      C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Cache
+        On Windows the only suggestion in the MSDN docs is that local settings go in
+        the `CSIDL_LOCAL_APPDATA` directory. This is identical to the non-roaming
+        app data dir (the default returned by `user_data_dir` above). Apps typically
+        put cache data somewhere *under* the given dir here. Some examples:
+            ...\Mozilla\Firefox\Profiles\<ProfileName>\Cache
+            ...\Acme\SuperApp\Cache\1.0
+        """
+        system = CA_DMV.get_system()
+        if system == "win32":
+            path = os.path.normpath(_get_win_folder("CSIDL_LOCAL_APPDATA"))
+            path = os.path.join(path, appname)
+            path = os.path.join(path, "Cache")
+        elif system == "darwin":
+            path = os.path.expanduser("~/Library/Caches")
+            path = os.path.join(path, appname)
+        else: # linux
+            path = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+            path = os.path.join(path, appname)
+        return path
+
+    # adapted from https://github.com/ActiveState/appdirs
+    def get_system():
+        if sys.platform.startswith("java"):
+            os_name = platform.java_ver()[3][0]
+            if os_name.startswith("Windows"): # "Windows XP", "Windows 7", etc.
+                return "win32"
+            elif os_name.startswith("Mac"): # "Mac OS X", etc.
+                return "darwin"
+            else: # "Linux", "SunOS", "FreeBSD", etc.
+                # Setting this to "linux2" is not ideal, but only Windows or Mac
+                # are actually checked for and the rest of the module expects
+                # *sys.platform* style strings.
+                return "linux2"
+        else:
+            return sys.platform

--- a/src/dmv.py
+++ b/src/dmv.py
@@ -41,11 +41,14 @@ class CA_DMV():
 
     def __init__(self):
         self.session = None
+        self.cache = {}
 
     def initialize(self):
         self.check_initialized(force = True)
 
     def check_plate(self, word):
+        if word in self.cache:
+            return self.cache[word]
         self.check_initialized(force = False)
         data = CA_DMV.build_plate_request_data(word)
         if not data:
@@ -59,6 +62,7 @@ class CA_DMV():
         if available is None:
             print("Got an unknown result for a plate, neither success nor failure!")
             return False
+        self.cache[word] = available
         return available
 
     def check_initialized(self, force = False):

--- a/src/dmv.py
+++ b/src/dmv.py
@@ -10,6 +10,8 @@ import sys
 from enum import Enum
 from pathlib import Path
 
+from appdirs import user_cache_dir
+
 logger = logging.getLogger(__name__)
 
 class CacheOption(Enum):
@@ -176,7 +178,7 @@ class CA_DMV():
             logger.debug("Could not clear disk cache - does not exist")
 
     def get_cache_path():
-        cache_dir = CA_DMV.user_cache_dir(CA_DMV.APPNAME)
+        cache_dir = user_cache_dir(CA_DMV.APPNAME)
         return os.path.join(cache_dir, CA_DMV.CACHE_FILE)
 
     def dmv_url(page):
@@ -251,50 +253,3 @@ class CA_DMV():
         else:
             logger.error("Unable to parse DMV response!")
             return None
-
-    # adapted from https://github.com/ActiveState/appdirs
-    def user_cache_dir(appname):
-        r"""Return full path to the user-specific cache dir for this application.
-
-        "appname" is the name of application.
-
-        Typical user cache directories are:
-            Mac OS X:   ~/Library/Caches/<AppName>
-            Unix:       ~/.cache/<AppName> (XDG default)
-            Win XP:     C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Cache
-            Vista:      C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Cache
-        On Windows the only suggestion in the MSDN docs is that local settings go in
-        the `CSIDL_LOCAL_APPDATA` directory. This is identical to the non-roaming
-        app data dir (the default returned by `user_data_dir` above). Apps typically
-        put cache data somewhere *under* the given dir here. Some examples:
-            ...\Mozilla\Firefox\Profiles\<ProfileName>\Cache
-            ...\Acme\SuperApp\Cache\1.0
-        """
-        system = CA_DMV.get_system()
-        if system == "win32":
-            path = os.path.normpath(_get_win_folder("CSIDL_LOCAL_APPDATA"))
-            path = os.path.join(path, appname)
-            path = os.path.join(path, "Cache")
-        elif system == "darwin":
-            path = os.path.expanduser("~/Library/Caches")
-            path = os.path.join(path, appname)
-        else: # linux
-            path = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
-            path = os.path.join(path, appname)
-        return path
-
-    # adapted from https://github.com/ActiveState/appdirs
-    def get_system():
-        if sys.platform.startswith("java"):
-            os_name = platform.java_ver()[3][0]
-            if os_name.startswith("Windows"): # "Windows XP", "Windows 7", etc.
-                return "win32"
-            elif os_name.startswith("Mac"): # "Mac OS X", etc.
-                return "darwin"
-            else: # "Linux", "SunOS", "FreeBSD", etc.
-                # Setting this to "linux2" is not ideal, but only Windows or Mac
-                # are actually checked for and the rest of the module expects
-                # *sys.platform* style strings.
-                return "linux2"
-        else:
-            return sys.platform

--- a/src/dmv.py
+++ b/src/dmv.py
@@ -8,7 +8,7 @@ class CA_DMV():
     PATH_PLATE = "processConfigPlate.do"
 
     START_DATA = {
-        "acknowledged": "true", 
+        "acknowledged": "true",
         "_acknowledged": "on",
     }
     PROCESS_DATA = {
@@ -45,17 +45,17 @@ class CA_DMV():
     def initialize(self):
         self.check_initialized(force = True)
 
-    def checkPlate(self, word):
+    def check_plate(self, word):
         self.check_initialized(force = False)
-        data = CA_DMV.buildPlateRequestData(word)
+        data = CA_DMV.build_plate_request_data(word)
         if not data:
             print("Invalid input, can't check the DMV.")
             return False
         result = self.session.post(
-            url = CA_DMV.dmvUrl(CA_DMV.PATH_PLATE), 
+            url = CA_DMV.dmv_url(CA_DMV.PATH_PLATE),
             data = data,
         )
-        available = CA_DMV.checkPlateResult(result)
+        available = CA_DMV.check_plate_response(result)
         if available is None:
             print("Got an unknown result for a plate, neither success nor failure!")
             return False
@@ -63,25 +63,25 @@ class CA_DMV():
 
     def check_initialized(self, force = False):
         if not self.session or force:
-            self.session = CA_DMV.initDmvSession()
+            self.session = CA_DMV.init_dmv_session()
 
-    def dmvUrl(page):
+    def dmv_url(page):
         return "{}/{}".format(CA_DMV.API_ROOT, page)
 
-    def initDmvSession():
+    def init_dmv_session():
         session = requests.Session()
-        session.get(url = CA_DMV.dmvUrl(CA_DMV.PATH_INIT))
+        session.get(url = CA_DMV.dmv_url(CA_DMV.PATH_INIT))
         session.post(
-            url = CA_DMV.dmvUrl(CA_DMV.PATH_START), 
+            url = CA_DMV.dmv_url(CA_DMV.PATH_START),
             data = CA_DMV.PROCESS_DATA,
         )
         session.post(
-            url = CA_DMV.dmvUrl(CA_DMV.PATH_PROCESS), 
+            url = CA_DMV.dmv_url(CA_DMV.PATH_PROCESS),
             data = CA_DMV.START_DATA,
         )
         return session
 
-    def buildPlateRequestData(word):
+    def build_plate_request_data(word):
         if len(word) < CA_DMV.MIN_LENGTH or len(word) > CA_DMV.MAX_LENGTH:
             return None
         data = CA_DMV.PLATE_DATA.copy()
@@ -90,7 +90,7 @@ class CA_DMV():
             data[param] = char
         return data
 
-    def checkPlateResult(response):
+    def check_plate_response(response):
         if CA_DMV.SUCCESS_PHRASE in response.text:
             return True
         elif CA_DMV.FAILURE_PHRASE in response.text:

--- a/src/dmv.py
+++ b/src/dmv.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import os
 import os.path
 import requests
 
 from enum import Enum
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 class CacheOption(Enum):
     DEFAULT = 1

--- a/src/vanity.py
+++ b/src/vanity.py
@@ -1,7 +1,10 @@
 import argparse
+import logging
 
 import license_explorer
 from dmv import CA_DMV, CacheOption
+
+logger = logging.getLogger("vanity")
 
 parser = argparse.ArgumentParser(description="Searches for vanity license plates.")
 parser.add_argument("input",
@@ -16,7 +19,16 @@ parser.add_argument("--dmv-test", dest="dmv_test", action="store_true",
                     help="if used, check the input against the CA DMV registry")
 parser.add_argument("--cache", type=CacheOption.from_string, choices=list(CacheOption), default=CacheOption.DEFAULT,
                     help="Cache configuration, for debugging (memory and disk by default)")
+log_mode = parser.add_mutually_exclusive_group()
+log_mode.add_argument("--debug", action="store_const", dest="loglevel", const=logging.DEBUG, default=logging.WARNING,
+                    help="Enable debug logs")
+log_mode.add_argument("-v", "--verbose", action="store_const", dest="loglevel", const=logging.INFO, default=logging.WARNING,
+                    help="Enable verbose (informational) logs")
 args = parser.parse_args()
+
+FORMAT = '[%(name)s][%(levelname).1s] %(message)s'
+logging.basicConfig(format=FORMAT, level=args.loglevel)
+logger.info("Logging with level: %s", logging.getLevelName(args.loglevel))
 
 if (args.dmv_test):
     print("Is \"{}\" available as a CA DMV license plate?...".format(args.input))

--- a/src/vanity.py
+++ b/src/vanity.py
@@ -4,13 +4,13 @@ import license_explorer
 from dmv import CA_DMV
 
 parser = argparse.ArgumentParser(description="Searches for vanity license plates.")
-parser.add_argument("input", 
+parser.add_argument("input",
                     help="The seed for the search, something like BREAD")
-parser.add_argument("-d", "--distance", type=int, default=3, 
+parser.add_argument("-d", "--distance", type=int, default=3,
                     help="The maximum distance to search (3 by default)")
-parser.add_argument("-w", "--output-width", type=int, default=10, 
+parser.add_argument("-w", "--output-width", type=int, default=10,
                     help="The maximum number of output per line in the output (10 by default)")
-parser.add_argument("-m", "--max-length", type=int, default=7, 
+parser.add_argument("-m", "--max-length", type=int, default=7,
                     help="The maximum length of the outputs (7 by default)")
 parser.add_argument("--dmv-test", dest="dmv_test", action="store_true",
                     help="if used, check the input against the CA DMV registry")
@@ -19,6 +19,6 @@ args = parser.parse_args()
 if (args.dmv_test):
     print("Is \"{}\" available as a CA DMV license plate?...".format(args.input))
     dmv = CA_DMV()
-    print(dmv.checkPlate(args.input))
+    print(dmv.check_plate(args.input))
 else:
     license_explorer.explore(args.input, args.distance, args.output_width, args.max_length)

--- a/src/vanity.py
+++ b/src/vanity.py
@@ -1,7 +1,7 @@
 import argparse
 
 import license_explorer
-from dmv import CA_DMV
+from dmv import CA_DMV, CacheOption
 
 parser = argparse.ArgumentParser(description="Searches for vanity license plates.")
 parser.add_argument("input",
@@ -14,11 +14,13 @@ parser.add_argument("-m", "--max-length", type=int, default=7,
                     help="The maximum length of the outputs (7 by default)")
 parser.add_argument("--dmv-test", dest="dmv_test", action="store_true",
                     help="if used, check the input against the CA DMV registry")
+parser.add_argument("--cache", type=CacheOption.from_string, choices=list(CacheOption), default=CacheOption.DEFAULT,
+                    help="Cache configuration, for debugging (memory and disk by default)")
 args = parser.parse_args()
 
 if (args.dmv_test):
     print("Is \"{}\" available as a CA DMV license plate?...".format(args.input))
-    dmv = CA_DMV()
+    dmv = CA_DMV(args.cache)
     print(dmv.check_plate(args.input))
 else:
     license_explorer.explore(args.input, args.distance, args.output_width, args.max_length)


### PR DESCRIPTION
## Overview

This PR makes three big changes:
* DMV results are now cached, mostly to speed up testing
* We now have logging, mostly to speed up dev time
* The input is now correctly validated and transformed to account for spaces

Other minor changes:
* Switch some CA_DMV functions to use snake casing instead of camel casing
* Add a dependency on [appdirs](https://pypi.org/project/appdirs/) to find a cache directory
* Add a dependency on [requests](https://pypi.org/project/requests/) (which we already had but didn't list)
* Update the README to explain how to update the environment (not just add a new one)

## Caching

The results of CA DMV requests are cached to disk, in JSON format, where the key is the request string and the value is whether or not it's available.

Here's an example cache file:
```
{"BREAD": false, "B8KERY": true}
```

The location of the cache file will depend on the operating system, but here's some example paths:
```
Windows: %AppData%\Local\Acme\SuperApp\Cache\vanity\ca_dmv.json
Mac: ~/Library/Caches/vanity/ca_dmv.json
Linux: ~/.cache/vanity/ca_dmv.json
```
There's both a disk cache, and an in memory cache.

Note:
* The cache (like the dmv request logic in general) is not thread safe.
* Note the new CLI commands (under `--cache`).

Possible future improvements:
* The in memory cache currently commits to disk on every change, this can be optimized.
* The cache entries should include timestamp so we can age out entries.

## Logging

We now have logging for the main file and for the CA DMV code paths. This uses the standard logging module, so we also get the benefit of seeing logs for any dependent libraries.

Example, viewing debug logs:
```
% python3 src/vanity.py --dmv-test b8kery --debug                          
[vanity][I] Logging with level: DEBUG
Is "b8kery" available as a CA DMV license plate?...
[dmv][D] Checking word: 'b8kery'
[dmv][D] Normalized word to: 'B8KERY'
[dmv][D] Loading cache from /Users/dtoro/Library/Caches/vanity/ca_dmv.json
[dmv][D] Successfully loaded 1 entries from the cache
[dmv][D] Initializing DMV request session
[urllib3.connectionpool][D] Starting new HTTPS connection (1): www.dmv.ca.gov:443
[urllib3.connectionpool][D] https://www.dmv.ca.gov:443 "GET /wasapp/ipp2/initPers.do HTTP/1.1" 200 None
[urllib3.connectionpool][D] https://www.dmv.ca.gov:443 "POST /wasapp/ipp2/startPers.do HTTP/1.1" 200 None
[urllib3.connectionpool][D] https://www.dmv.ca.gov:443 "POST /wasapp/ipp2/processPers.do HTTP/1.1" 200 None
[urllib3.connectionpool][D] https://www.dmv.ca.gov:443 "POST /wasapp/ipp2/processConfigPlate.do HTTP/1.1" 200 None
[dmv][I] Success in DMV response!
[dmv][D] Got result from API: ('B8KERY': True)
[dmv][D] Saving 2 cache entries to /Users/dtoro/Library/Caches/vanity/ca_dmv.json
True
```

Note:
* Logs go to the error stream, so you can redirect that to suppress all logging
* Note the new CLI commands (under `--verbose` and `--debug`).

Possible future improvements:
* Logging can be expanded to the search tree as well.

## Input validation

There are four improvements to the way input is validated:
* Instead of simply checking length requirements, we also check character requirements through a series of regular expressions.
* The DMV response is more carefully checked for known errors, so that we can detect requirements that we missed.
* Spaces are now handled properly, in that we strip them away before checking with the DMV.
* We uppercase for you so you don't have to (`bread` to `BREAD`).

Special note for spaces: the way the DMV accepts spaces is by converting them to asterisks, i.e. `' '` to `'*'`. I could have done this, but since it ignores spaces in the uniqueness check, I figured it was simpler to strip them away. This has the side effect of making our cache more efficient, since `BREAD` and `B READ` will both be normalized to the same string.

## Changed CLI arguments

Added:
* `--cache`: This lets you skip the memory cache (so every call goes to the DMV), skip the disk cache (to ignore previous runs), or clear the disk cache (in case it has stale entries).
* `-v` or `--verbose`: Prints information logging (by default, we only print warnings and errors). Good for power users.
* `--debug`: Like verbose, but also prints debug logging. Good for developers.

Here's what the full help looks like now:
```
% python3 src/vanity.py -h       
usage: vanity.py [-h] [-d DISTANCE] [-w OUTPUT_WIDTH] [-m MAX_LENGTH]
                 [--dmv-test]
                 [--cache {DEFAULT,SKIP_MEM_CACHE,SKIP_DISK_CACHE,CLEAR_DISK_CACHE}]
                 [--debug | -v]
                 input

Searches for vanity license plates.

positional arguments:
  input                 The seed for the search, something like BREAD

optional arguments:
  -h, --help            show this help message and exit
  -d DISTANCE, --distance DISTANCE
                        The maximum distance to search (3 by default)
  -w OUTPUT_WIDTH, --output-width OUTPUT_WIDTH
                        The maximum number of output per line in the output
                        (10 by default)
  -m MAX_LENGTH, --max-length MAX_LENGTH
                        The maximum length of the outputs (7 by default)
  --dmv-test            if used, check the input against the CA DMV registry
  --cache {DEFAULT,SKIP_MEM_CACHE,SKIP_DISK_CACHE,CLEAR_DISK_CACHE}
                        Cache configuration, for debugging (memory and disk by
                        default)
  --debug               Enable debug logs
  -v, --verbose         Enable verbose (informational) logs
```