### PR TITLE
Switch to Dijkstra's algorithm, refactor transformation functions

### DIFF
--- a/src/license_explorer.py
+++ b/src/license_explorer.py
@@ -1,33 +1,9 @@
-from utils import Option, PrioritizedItem
+from utils import Option
 from utils import print_options
 from queue import PriorityQueue
 from typing import List
 
-from transformations import transform_letters_to_numbers
-from transformations import transform_substrings_to_numbers
-from transformations import remove_middle_vowels
-from transformations import find_synonyms
-from transformations import remove_middle_consinent
-from transformations import change_letters
-from transformations import remove_start_or_end
-
-transformation_functions = {
-    transform_letters_to_numbers: 1,
-    transform_substrings_to_numbers: 1,
-    remove_middle_vowels: 1,
-    find_synonyms: 1,
-    remove_middle_consinent: 3,
-    change_letters: 5,
-    remove_start_or_end: 10,
-}
-
-def transform(option: Option) -> List[Option]:
-    results = []
-    for f in transformation_functions.keys():
-        new_distance = option.distance + transformation_functions[f]
-        derived = f(option)
-        results.extend(Option(word=d, distance=new_distance) for d in derived)
-    return results
+from transformations import transform
 
 def search(input_word, max_distance):
     '''Just Dijkstra's algorithm'''

--- a/src/transformations.py
+++ b/src/transformations.py
@@ -1,6 +1,30 @@
-from dictionary_builder import get_dictionary
+from __future__ import annotations
 
-vowels = ["A", "E", "I", "O", "U"]
+from dictionary_builder import get_dictionary
+from dataclasses import dataclass
+from utils import Option, Transform
+from typing import List
+
+@dataclass
+class KeyedTransform(Transform):
+    key: str
+
+@dataclass
+class NumberTransform(KeyedTransform):
+    value: str
+
+@dataclass
+class SubstringTransform(KeyedTransform):
+    value: str
+
+@dataclass
+class RemoveVowelTransform(KeyedTransform):
+    key: str
+
+@dataclass
+class SynonymTransform(Transform):
+    pass
+
 consonants = [
     "B", "C", "D", "F", "G",
     "H", "J", "K", "L", "M",
@@ -8,80 +32,117 @@ consonants = [
     "T", "V", "W", "X", "Y", "Z",
 ]
 
-number_transforms = {
-    # "O": "0",
-    "L": "1",
-    "I": "1",
-    "Z": "2",
-    #"R": "2",
-    "E": "3",
-    "A": "4",
-    "S": "5",
-    #"G": "6",
-    #"C": "6",
-    "T": "7",
-    #"Y": "7",
-    "B": "8",
-    "G": "9",
-}
+transforms = [
+    NumberTransform(1, "L", "1"),
+    NumberTransform(1, "I", "1"),
+    NumberTransform(1, "Z", "2"),
+    NumberTransform(1, "E", "3"),
+    NumberTransform(1, "A", "4"),
+    NumberTransform(1, "S", "5"),
+    NumberTransform(1, "T", "7"),
+    NumberTransform(1, "B", "8"),
+    NumberTransform(1, "G", "9"),
+    SubstringTransform(1, "TOO", "2"),
+    SubstringTransform(1, "TWO", "2"),
+    SubstringTransform(1, "TO" , "2"),
+    SubstringTransform(1, "FOR", "4"),
+    SubstringTransform(1, "FOUR", "4"),
+    RemoveVowelTransform(1, "A"),
+    RemoveVowelTransform(1, "E"),
+    RemoveVowelTransform(1, "I"),
+    RemoveVowelTransform(1, "O"),
+    RemoveVowelTransform(1, "U"),
+    SynonymTransform(1),
+]
 
-substring_transforms = {
-    "TOO" : "2",
-    "TWO" : "2",
-    "TO"  : "2",
-    "FOR" : "4",
-    "FOUR": "4",
-}
+def get_keyed_transform(_class: type[KeyedTransform]):
+    return { x.key: x for x in transforms if isinstance(x, _class) }
 
-def transform_letters_to_numbers(w):
+def get_transform(_class: type[Transform]):
+    return next((x for x in transforms if isinstance(x, _class)))
+
+number_transforms = get_keyed_transform(NumberTransform)
+substring_transforms = get_keyed_transform(SubstringTransform)
+remove_vowel_transforms = get_keyed_transform(RemoveVowelTransform)
+synonym_transform = get_transform(SynonymTransform)
+
+def transform_letters_to_numbers(option: Option) -> List[Option]:
     to_ret = []
-    for i, c in enumerate(w.word):
+    for i, c in enumerate(option.word):
         if c in number_transforms.keys():
-            to_ret.append(w.word[:i] + number_transforms[c] + w.word[i+1:])
+            t = number_transforms[c]
+            new_word = option.word[:i] + t.value + option.word[i+1:]
+            to_ret.append(option.jump(new_word, t))
     return to_ret
 
-def transform_substrings_to_numbers(w):
+def transform_substrings_to_numbers(option: Option) -> List[Option]:
     to_ret = []
     # This could be improved by using KMP or something, but time to build maps probably outweighs
     # n^2 here for now.
-    for i in range(len(w.word)):
+    for i in range(len(option.word)):
         for sub in substring_transforms.keys():
-            if w.word[i:i+len(sub)] == sub:
-                to_ret.append(w.word[:i] + substring_transforms[sub] + w.word[i+len(sub):])
+            if option.word[i:i+len(sub)] == sub:
+                t = substring_transforms[sub]
+                new_word = option.word[:i] + t.value + option.word[i+len(sub):]
+                to_ret.append(option.jump(new_word, t))
     return to_ret
 
-def remove_middle_vowels(w):
+def remove_middle_vowels(option: Option) -> List[Option]:
     to_ret = []
 
-    for idx, l in enumerate(w.word):
-        if l in vowels and idx != 0 and idx != len(w.word) - 1:
-            to_ret.append(w.word[:idx] + w.word[idx+1:])
+    for idx, l in enumerate(option.word):
+        t = remove_vowel_transforms.get(l, None)
+        if t and idx != 0 and idx != len(option.word) - 1:
+            new_word = option.word[:idx] + option.word[idx+1:]
+            to_ret.append(option.jump(new_word, t))
 
     return to_ret
 
 dictionary = get_dictionary()
-def find_synonyms(w):
-    if w.word in dictionary.keys():
-        return dictionary[w.word].synonyms
-    elif len(w.word.split()) > 1:
-        list_to_return = []
-        starting_phrase = w.word.split()
+def find_synonyms(option: Option) -> List[Option]:
+    if not synonym_transform:
+        return []
+
+    to_ret = []
+
+    if option.word in dictionary.keys():
+        for syn in dictionary[option.word].synonyms:
+            to_ret.append(option.jump(syn, synonym_transform))
+    
+    if len(option.word.split()) > 1:
+        starting_phrase = option.word.split()
         for idx, sub_part in enumerate(starting_phrase):
             if not sub_part in dictionary.keys():
                 continue
             for syn in dictionary[sub_part].synonyms:
                 copy_starting_phrase = starting_phrase.copy()
                 copy_starting_phrase[idx] = syn
-                list_to_return.append(" ".join(copy_starting_phrase))
-        return list_to_return
-    else:
-        return []
+                new_word = " ".join(copy_starting_phrase)
+                to_ret.append(option.jump(new_word, synonym_transform))
+                
+    return to_ret
 
-def remove_middle_consinent(w):
+def remove_middle_consonent(option: Option) -> List[Option]:
     return []
 
-def change_letters(w):
+def change_letters(option: Option) -> List[Option]:
     return []
 
-def remove_start_or_end(w):
+def remove_start_or_end(option: Option) -> List[Option]:
     return []
+
+transformation_functions = [
+    transform_letters_to_numbers,
+    transform_substrings_to_numbers,
+    remove_middle_vowels,
+    find_synonyms,
+    remove_middle_consonent,
+    change_letters,
+    remove_start_or_end,
+]
+
+def transform(option: Option) -> List[Option]:
+    results = []
+    for f in transformation_functions:
+        results.extend(f(option))
+    return results

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import List, Any, Iterable, TypeVar, Callable
 from collections import defaultdict
@@ -15,6 +17,10 @@ SYMBOLS = {
     },
 }
 
+@dataclass
+class Transform:
+    cost: int
+
 @dataclass(order=True, frozen=True)
 class PrioritizedItem:
     priority: int
@@ -27,6 +33,9 @@ class Option:
 
     def to_priority(self) -> PrioritizedItem:
         return PrioritizedItem(priority = self.distance, item = self)
+
+    def jump(self, new_word: str, transform: Transform) -> Option:
+        return Option(word = new_word, distance = self.distance + transform.cost)
 
 def print_options(options: List[Option], width: int, max_length: int, dmv, use_emoji: bool):
     grouped = group_by(options, lambda x: x.distance, lambda x: x.word)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import List, Any, Iterable, TypeVar, Callable
+from collections import defaultdict
 
 SYMBOLS = {
     False: {
@@ -13,31 +15,47 @@ SYMBOLS = {
     },
 }
 
-def print_options_at_distance(d, words, width, max_length, dmv, use_emoji):
-    print(f"DISTANCE {d}")
-    filtered = (w.word for w in words if w.distance == d and len(w.word) <= max_length)
-    if dmv:
-        filtered = (with_result(w, dmv.check_plate(w), use_emoji) for w in filtered)
-    print_grouped(sorted(filtered), width)
+@dataclass(order=True, frozen=True)
+class PrioritizedItem:
+    priority: int
+    item: Any=field(compare=False)
 
-def print_grouped(words, width):
+@dataclass(order=True, frozen=True)
+class Option:
+    word: str
+    distance: int=field(compare=False)
+
+    def to_priority(self) -> PrioritizedItem:
+        return PrioritizedItem(priority = self.distance, item = self)
+
+def print_options(options: List[Option], width: int, max_length: int, dmv, use_emoji: bool):
+    grouped = group_by(options, lambda x: x.distance, lambda x: x.word)
+    by_distance = sorted(grouped.items(), key=lambda x: x[0])
+    for distance, words in by_distance:
+        print_words_at_distance(distance, words, width, max_length, dmv, use_emoji)
+
+def print_words_at_distance(d: int, words: List[str], width: int, max_length: int, dmv, use_emoji: bool):
+    print(f"DISTANCE {d}")
+    words = sorted(w for w in words if len(w) <= max_length)
+    if dmv:
+        words = (with_result(w, dmv.check_plate(w), use_emoji) for w in words)
+    print_grouped(words, width)
+
+def print_grouped(words: List[Option], width: int):
     grouped = [words[i:i+width] for i in range(0, len(words), width)]
     for g in grouped:
         print("\t", "".join("{:<11}".format(w) for w in g))
 
-def with_result(word, result, use_emoji):
+def with_result(word: str, result: bool, use_emoji: bool) -> str:
     symbol = SYMBOLS[use_emoji][result]
     return word + " " + symbol
 
-@dataclass
-class Option:
-    word: str
-    distance: int
+T = TypeVar("T")
 
-    def __hash__(self):
-        return hash(self.word)
-
-    def __eq__(self, other):
-        if not isinstance(other, type(self)):
-            return False
-        return self.word == other.word
+def group_by(iterable: Iterable[T], key: Callable[[T], Any], value: Callable[[T], Any] = None):
+    if not value:
+        value = lambda x: x
+    result = defaultdict(list)
+    for item in iterable:
+        result[key(item)].append(value(item))
+    return result

--- a/src/utils.py
+++ b/src/utils.py
@@ -48,7 +48,7 @@ def print_words_at_distance(d: int, words: List[str], width: int, max_length: in
     words = sorted(w for w in words if len(w) <= max_length)
     if dmv:
         words = (with_result(w, dmv.check_plate(w), use_emoji) for w in words)
-    print_grouped(words, width)
+    print_grouped(list(words), width)
 
 def print_grouped(words: List[Option], width: int):
     grouped = [words[i:i+width] for i in range(0, len(words), width)]


### PR DESCRIPTION
Before this change, each type of transformation had a fixed cost, so swapping `"8"` for `"B"` added the same distance as swapping `"I"` for `"1"`.

While adjusting this I also decided to simplify the search algorithm, so this PR has two changes:

## Switch to Dijkstra's algorithm

Previously, the `explore` function was doing something pretty close to Dijkstra's, but I suspect there were some hidden bugs having to do with ignoring lower cost paths.

In order to be sure, I adjusted the implementation to more closely match [Dijkstra's algorithm using a priority queue](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm#Using_a_priority_queue).

Also, I simplified the `Option` class by using the `compare=false` flag on `distance`, getting rid of the need for a custom hash function.

## Refactor transformation functions

Now each transformation defines its own cost, so we can adjust them independently. I also added some more dataclasses so we can keep all of the possibilities in one list.

I'm thinking that this can eventually be configurable by the user, so they can enable/disable/prioritize transformations differently.

Also, it'd be nice to somehow weigh synonyms differently too, but I don't think our dictionary has a score...

Oh, and also fixed a bug where if a compound word had a direct synonym, we didn't look for substring synonyms.